### PR TITLE
[Settings] Fix 'Unrecognized option' error when saving Chromium processor config

### DIFF
--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -70,9 +70,12 @@ class SettingsController extends UserAwareController
 
         $values = $this->decodeJson($request->get('data'));
 
-        unset($values['documentation']);
-        unset($values['additions']);
-        unset($values['json_converter']);
+        unset(
+            $values['documentation'],
+            $values['requirements'],
+            $values['additions'],
+            $values['json_converter'],
+        );
 
         Config::save($values);
 


### PR DESCRIPTION
The field `requirements` is for documentation purpose and is not included in bundle's Symfony config. Unset this key on save as well.