### PR TITLE
[Gotenberg] Set assets

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -253,6 +253,7 @@ abstract class Processor
     {
         $document = $params['document'] ?? null;
         $hostUrl = $params['hostUrl'] ?? null;
+        $processor = $params['processor'] ?? null;
         $templatingEngine = \Pimcore::getContainer()->get('pimcore.templating.engine.delegating');
 
         try {
@@ -266,6 +267,10 @@ abstract class Processor
             throw new \Exception(sprintf('Failed rendering the print template: %s. Please check your twig sandbox security policy or contact the administrator.', $e->getMessage()));
         } finally {
             $templatingEngine->disableSandboxExtensionFromTwigEnvironment();
+        }
+
+        if ($processor instanceof Gotenberg) {
+            return $html;
         }
 
         return Mail::setAbsolutePaths($html, $document, $hostUrl);

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -247,7 +247,7 @@ class Gotenberg extends Processor
 
                 $assets[] = [
                     'path' => urldecode($localFilePath),
-                    'name' => urldecode($fileName),
+                    'filename' => urldecode($fileName),
                 ];
 
                 $path = preg_quote($path, '!');
@@ -290,7 +290,7 @@ class Gotenberg extends Processor
 
                 $assets[] = [
                     'path' => str_replace([' 1x', ' 2x', '@2x'], '', urldecode($localFilePath)),
-                    'name' => urldecode($fileName),
+                    'filename' => urldecode($fileName),
                 ];
 
                 $parts[$key] = $fileName;

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -229,7 +229,7 @@ class Gotenberg extends Processor
 
                 $subPath = '/var/assets';
 
-                if (s($path)->containsAny(['css', 'js']) === true) {
+                if (s($path)->containsAny(['css', 'js', 'ttf']) === true) {
                     $subPath = '';
                 }
 

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -62,7 +62,7 @@ class Gotenberg extends Processor
             }
         }
 
-        if (emtpy($assets) === false) {
+        if (empty($assets) === false) {
             $gotenbergSettings['assets'] = $assets;
         }
 


### PR DESCRIPTION
Possible solution for #32 

If the processor is Gotenberg we do not set absolute paths for the additional files but just return them. Then we have a new function that goes through the html similar to the `Mail::setAbsolutePaths` function and gets all the images. There the full local path is generated from the image path and saved along with the filename in a new array. The path in the html will be replaced with only the filename so it is on root level. At last, the assets in the new array will be loaded as stream and sent together with everything else to Gotenberg to render the PDF.

As mentioned in the issue this is not a really nice solution but its working for us.