### PR TITLE
[Task]: Remove unecessary if condition when setting margins via Gotenberg

### DIFF
--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -118,7 +118,11 @@ class Gotenberg extends Processor
             }
         }
 
-        if ($params['marginTop'] ?? $params['marginBottom'] ?? $params['marginLeft'] ?? isset($params['marginRight'])) {
+        if (isset($params['marginTop'])
+            || isset($params['marginBottom'])
+            || isset($params['marginLeft'])
+            || isset($params['marginRight'])
+        ) {
             $chromium->margins(
                 $params['marginTop'] ?? 0.39,
                 $params['marginBottom'] ?? 0.39,

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -118,18 +118,12 @@ class Gotenberg extends Processor
             }
         }
 
-        if (isset($params['marginTop'])
-            || isset($params['marginBottom'])
-            || isset($params['marginLeft'])
-            || isset($params['marginRight'])
-        ) {
-            $chromium->margins(
-                $params['marginTop'] ?? 0.39,
-                $params['marginBottom'] ?? 0.39,
-                $params['marginLeft'] ?? 0.39,
-                $params['marginRight'] ?? 0.39
-            );
-        }
+        $chromium->margins(
+            $params['marginTop'] ?? 0.39,
+            $params['marginBottom'] ?? 0.39,
+            $params['marginLeft'] ?? 0.39,
+            $params['marginRight'] ?? 0.39
+        );
 
         if (isset($params['scale'])) {
             $chromium->scale($params['scale']);


### PR DESCRIPTION
If you would set any of the margins, except marginRight to 0 the if condition would evaluate to false and therefore the margins won't be set. By checking all with isset the condition would be true if any one of them is set and the margins will be applied