### PR TITLE
Fix: ManyToManyRelation have wrong phpdocs when use print documents

### DIFF
--- a/config/pimcore/default.yaml
+++ b/config/pimcore/default.yaml
@@ -7,12 +7,12 @@ pimcore:
         type_definitions:
             map:
                 printpage:
-                    class: Pimcore\Bundle\WebToPrintBundle\Model\Document\Printpage
+                    class: \Pimcore\Bundle\WebToPrintBundle\Model\Document\Printpage
                     children_supported: false
                     direct_route: true
                     predefined_document_types: true
                 printcontainer:
-                    class: Pimcore\Bundle\WebToPrintBundle\Model\Document\Printcontainer
+                    class: \Pimcore\Bundle\WebToPrintBundle\Model\Document\Printcontainer
                     only_printable_childrens: true
                     direct_route: true
                     predefined_document_types: true


### PR DESCRIPTION
The \ is missing at the begin of the class name.

Before:
```
/**
* Get sources - testclass.testfield
* @return Pimcore\Bundle\WebToPrintBundle\Model\Document\Printpage[]|Pimcore\Bundle\WebToPrintBundle\Model\Document\Printcontainer[]
*/
public function getTestfield(): array
{
	...
}
```

After:
```
/**
* Get sources - testclass.testfield
* @return \Pimcore\Bundle\WebToPrintBundle\Model\Document\Printpage[]|\Pimcore\Bundle\WebToPrintBundle\Model\Document\Printcontainer[]
*/
public function getTestfield(): array
{
	...
}
```