### PR TITLE
Gotenberg V8 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "phpstan/phpstan": "^1.10.5",
     "phpstan/phpstan-symfony": "^1.2.20",
-    "gotenberg/gotenberg-php": "^1.0.0",
+    "gotenberg/gotenberg-php": "^1.0|^2.0",
     "chrome-php/chrome": "^1.8",
     "codeception/codeception": "^5.0.3",
     "codeception/module-symfony": "^3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "phpstan/phpstan": "^1.10.5",
     "phpstan/phpstan-symfony": "^1.2.20",
-    "gotenberg/gotenberg-php": "^1.0|^2.0",
+    "gotenberg/gotenberg-php": "^1.0||^2.0",
     "chrome-php/chrome": "^1.8",
     "codeception/codeception": "^5.0.3",
     "codeception/module-symfony": "^3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "phpstan/phpstan": "^1.10.5",
     "phpstan/phpstan-symfony": "^1.2.20",
-    "gotenberg/gotenberg-php": "^1.0||^2.0",
+    "gotenberg/gotenberg-php": "^1.0 || ^2.0",
     "chrome-php/chrome": "^1.8",
     "codeception/codeception": "^5.0.3",
     "codeception/module-symfony": "^3.1.0",

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -111,10 +111,10 @@ class Gotenberg extends Processor
             $chromium = $chromium->pdf();
         } else {
             // gotenberg-php v1 BC Layer for unsupported methods in v2
-            if (isset($params['userAgent'])) {
+            if (isset($params['userAgent']) && method_exists($chromium, 'userAgent')) {
                $chromium->userAgent($params['userAgent']);
             }
-            if (isset($params['pdfFormat'])) {
+            if (isset($params['pdfFormat'])&& method_exists($chromium, 'pdfFormat')) {
                $chromium->pdfFormat($params['pdfFormat']);
             }
         }

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -106,6 +106,9 @@ class Gotenberg extends Processor
         $tempFileName = uniqid('web2print_');
 
         $chromium = GotenbergAPI::chromium(\Pimcore\Config::getSystemConfiguration('gotenberg')['base_url']);
+        if (method_exists($chromium, 'pdf')) {
+            $chromium = $chromium->pdf();
+        }
 
         $options = [
             'printBackground', 'landscape', 'preferCssPageSize', 'omitBackground', 'emulatePrintMediaType',
@@ -134,7 +137,7 @@ class Gotenberg extends Processor
         }
 
         foreach (['header', 'footer'] as $item) {
-            if (isset($params[$item . 'Template'])) {
+            if (isset($params[$item . 'Template']) && method_exists($chromium, $item)) {
                 $chromium->$item(Stream::path($params[$item . 'Template']));
             }
         }
@@ -143,7 +146,7 @@ class Gotenberg extends Processor
             $chromium->paperSize($params['paperWidth'] ?? 8.5, $params['paperHeight'] ?? 11);
         }
 
-        if (isset($params['userAgent'])) {
+        if (isset($params['userAgent']) && method_exists($chromium, 'userAgent')) {
             $chromium->userAgent($params['userAgent']);
         }
 
@@ -151,7 +154,7 @@ class Gotenberg extends Processor
             $chromium->extraHttpHeaders($params['extraHttpHeaders']);
         }
 
-        if (isset($params['pdfFormat'])) {
+        if (isset($params['pdfFormat']) && method_exists($chromium, 'pdfFormat')) {
             $chromium->pdfFormat($params['pdfFormat']);
         }
 

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -137,7 +137,7 @@ class Gotenberg extends Processor
         }
 
         foreach (['header', 'footer'] as $item) {
-            if (isset($params[$item . 'Template']) && method_exists($chromium, $item)) {
+            if (isset($params[$item . 'Template'])) {
                 $chromium->$item(Stream::path($params[$item . 'Template']));
             }
         }

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -155,16 +155,9 @@ class Gotenberg extends Processor
             $chromium->paperSize($params['paperWidth'] ?? 8.5, $params['paperHeight'] ?? 11);
         }
 
-        if (isset($params['userAgent']) && method_exists($chromium, 'userAgent')) {
-            $chromium->userAgent($params['userAgent']);
-        }
 
         if (isset($params['extraHttpHeaders'])) {
             $chromium->extraHttpHeaders($params['extraHttpHeaders']);
-        }
-
-        if (isset($params['pdfFormat']) && method_exists($chromium, 'pdfFormat')) {
-            $chromium->pdfFormat($params['pdfFormat']);
         }
 
         $request = $chromium->outputFilename($tempFileName)->html(Stream::string('processor.html', $html));

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -106,8 +106,17 @@ class Gotenberg extends Processor
         $tempFileName = uniqid('web2print_');
 
         $chromium = GotenbergAPI::chromium(\Pimcore\Config::getSystemConfiguration('gotenberg')['base_url']);
+        // To support gotenberg-php v2 and so on
         if (method_exists($chromium, 'pdf')) {
             $chromium = $chromium->pdf();
+        } else {
+            // gotenberg-php v1 BC Layer for unsupported methods in v2
+            if (isset($params['userAgent'])) {
+               $chromium->userAgent($params['userAgent']);
+            }
+            if (isset($params['pdfFormat'])) {
+               $chromium->pdfFormat($params['pdfFormat']);
+            }
         }
 
         $options = [


### PR DESCRIPTION
Add compatibilty to new version of gotenberg/gotenberg-php (v2.0.0) which supports Gotenberg V8, but still keep support in this package for older version