### PR TITLE
Add Gotenberg option generateDocumentOutline to $options array

### DIFF
--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -128,7 +128,7 @@ class Gotenberg extends Processor
 
         $options = [
             'printBackground', 'landscape', 'preferCssPageSize', 'omitBackground', 'emulatePrintMediaType',
-            'emulateScreenMediaType',
+            'emulateScreenMediaType', 'generateDocumentOutline',
         ];
 
         foreach ($options as $option) {

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -138,7 +138,7 @@ class Gotenberg extends Processor
         }
 
         // generateDocumentOutline is only available for gotenberg >= 8.14.0 and gotenberg-php >= v2.10.0
-        if (isset($params['generateDocumentOutline']) && $params['generateDocumentOutline'] != false) {
+        if (isset($params['generateDocumentOutline']) && $params['generateDocumentOutline']) {
             $chromium->generateDocumentOutline();
         }
 

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -138,7 +138,8 @@ class Gotenberg extends Processor
         }
 
         // generateDocumentOutline is only available for gotenberg >= 8.14.0 and gotenberg-php >= v2.10.0
-        if (isset($params['generateDocumentOutline']) && $params['generateDocumentOutline']) {
+        if (isset($params['generateDocumentOutline']) && $params['generateDocumentOutline']
+            && method_exists($chromium, 'generateDocumentOutline')) {
             $chromium->generateDocumentOutline();
         }
 

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -132,7 +132,7 @@ class Gotenberg extends Processor
         ];
 
         foreach ($options as $option) {
-            if (isset($params[$option]) && $params[$option] != false) {
+            if (isset($params[$option]) && $params[$option] != false && method_exists($chromium, $option)) {
                 $chromium->$option();
             }
         }

--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -128,13 +128,18 @@ class Gotenberg extends Processor
 
         $options = [
             'printBackground', 'landscape', 'preferCssPageSize', 'omitBackground', 'emulatePrintMediaType',
-            'emulateScreenMediaType', 'generateDocumentOutline',
+            'emulateScreenMediaType',
         ];
 
         foreach ($options as $option) {
-            if (isset($params[$option]) && $params[$option] != false && method_exists($chromium, $option)) {
+            if (isset($params[$option]) && $params[$option] != false) {
                 $chromium->$option();
             }
+        }
+
+        // generateDocumentOutline is only available for gotenberg >= 8.14.0 and gotenberg-php >= v2.10.0
+        if (isset($params['generateDocumentOutline']) && $params['generateDocumentOutline'] != false) {
+            $chromium->generateDocumentOutline();
         }
 
         $chromium->margins(


### PR DESCRIPTION
This should allow creating a document outline based on the HTML heading structure in the PDF file