### PR TITLE
Adding perspectives permissions to bundle

### DIFF
--- a/public/js/startup.js
+++ b/public/js/startup.js
@@ -3,9 +3,39 @@ pimcore.registerNS("pimcore.bundle.web2print.startup");
 pimcore.bundle.web2print.startup = Class.create({
 
     initialize: function () {
+        if (pimcore.events.onPerspectiveEditorLoadPermissions) {
+            document.addEventListener(pimcore.events.onPerspectiveEditorLoadPermissions, this.addMenuPermissions.bind(this));
+            document.addEventListener(pimcore.events.onPerspectiveEditorLoadPermissions, this.addContextMenuPermissions.bind(this));
+        }
+
         document.addEventListener(pimcore.events.preMenuBuild, this.preMenuBuild.bind(this));
         document.addEventListener(pimcore.events.prepareDocumentTreeContextMenu, this.onPrepareDocumentTreeContextMenu.bind(this));
     },
+
+    addMenuPermissions: function (e) {
+        const context = e.detail.context;
+        const menu = e.detail.menu;
+        const permissions = e.detail.permissions;
+
+        if(context === 'toolbar' & menu === 'settings' &&
+           permissions[context][menu].indexOf('items.web2print') === -1) {
+            permissions[context][menu].push('items.web2print');
+        }
+    },
+
+    addContextMenuPermissions: function (e) {
+        const context = e.detail.context;
+        const menu = e.detail.menu;
+        const permissions = e.detail.permissions;
+
+        if (context === 'customViewContextMenu' && menu === 'document') {
+            ['items.addPrintPage', 'items.addBlankPrintPage'].forEach((permission) => {
+                if (permissions[context][menu].indexOf(permission) === -1) {
+                    permissions[context][menu].push(permission);
+                }
+            });
+        }
+    }, 
 
     preMenuBuild: function (e) {
         let menu = e.detail.menu;

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -1,5 +1,8 @@
 add_printpage: Add PrintPage
 add_printcontainer: Add PrintContainer
+plugin_pimcore_perspectiveeditor_document_items_addPrintPage: "Add PrintPage"
+plugin_pimcore_perspectiveeditor_document_items_addBlankPrintPage: "Add PrintPage > Blank"
+plugin_pimcore_perspectiveeditor_menu_settings_items_web2print: "Web-to-Print Settings"
 web2print_settings: Web-to-Print Settings
 web2print_preview_pdf: Generate & Preview PDF
 web2print_cancel_pdf_creation: Cancel PDF Creation


### PR DESCRIPTION
Solves 2 things from Persepective Editor bundle:

- Related https://github.com/pimcore/perspective-editor/pull/169 and moving permission to bundle.
- Related https://github.com/pimcore/perspective-editor/issues/142 - Added permission to manage "Blank" menu item in context menu.

Please review,