### PR TITLE
Symfony7 next steps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php": "~8.3.0 || ~8.4.0",
     "doctrine/dbal": "^4.0",
     "pimcore/admin-ui-classic-bundle": "^2.0",
-    "pimcore/pimcore": "^12.0"
+    "pimcore/pimcore": "^12.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.10.5",

--- a/src/Controller/Document/PrintpageControllerBase.php
+++ b/src/Controller/Document/PrintpageControllerBase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\WebToPrintBundle\Controller\Document;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Exception;
 use Pimcore\Bundle\AdminBundle\Controller\Admin\Document\DocumentControllerBase;
 use Pimcore\Bundle\WebToPrintBundle\Config;
@@ -38,7 +39,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
     #[Route('/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
-        $page = PrintAbstract::getById($request->query->getInt('id'));
+        $page = PrintAbstract::getById(ParameterBagHelper::getInt($request->query, 'id'));
 
         if (!$page) {
             throw $this->createNotFoundException('Document not found');
@@ -85,7 +86,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
     #[Route('/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request): JsonResponse
     {
-        $page = PrintAbstract::getById($request->request->getInt('id'));
+        $page = PrintAbstract::getById(ParameterBagHelper::getInt($request->request, 'id'));
         if (!$page) {
             throw $this->createNotFoundException('Document not found');
         }
@@ -136,7 +137,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
         $errorMessage = '';
 
         // check for permission
-        $parentDocument = Document::getById($request->request->getInt('parentId'));
+        $parentDocument = Document::getById(ParameterBagHelper::getInt($request->request, 'parentId'));
         $document = null;
         if ($parentDocument->isAllowed('create')) {
             $intendedPath = $parentDocument->getRealFullPath() . '/' . $request->request->getString('key');
@@ -165,7 +166,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
                 }
 
                 if ($request->request->has('inheritanceSource')) {
-                    $createValues['contentMainDocumentId'] = $request->request->getInt('inheritanceSource');
+                    $createValues['contentMainDocumentId'] = ParameterBagHelper::getInt($request->request, 'inheritanceSource');
                 }
 
                 $className = \Pimcore::getContainer()->get('pimcore.class.resolver.document')->resolve($request->request->getString('type'));
@@ -191,7 +192,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
         }
 
         if ($success && $document instanceof Document) {
-            if ($translationsBaseDocumentId = $request->request->getInt('translationsBaseDocument')) {
+            if ($translationsBaseDocumentId = ParameterBagHelper::getInt($request->request, 'translationsBaseDocument')) {
                 $translationsBaseDocument = Document::getById($translationsBaseDocumentId);
 
                 $properties = $translationsBaseDocument->getProperties();
@@ -230,10 +231,10 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
     #[Route('/active-generate-process', name: 'activegenerateprocess', methods: ['POST'])]
     public function activeGenerateProcessAction(Request $request): JsonResponse
     {
-        $document = PrintAbstract::getById($request->request->getInt('id'));
+        $document = PrintAbstract::getById(ParameterBagHelper::getInt($request->request, 'id'));
 
         if (!$document) {
-            throw $this->createNotFoundException('Document with id ' . $request->request->getInt('id') . ' not found.');
+            throw $this->createNotFoundException('Document with id ' . ParameterBagHelper::getInt($request->request, 'id') . ' not found.');
         }
 
         $date = $document->getLastGeneratedDate();
@@ -263,10 +264,10 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
     #[Route('/pdf-download', name: 'pdfdownload', methods: ['GET'])]
     public function pdfDownloadAction(Request $request): BinaryFileResponse
     {
-        $document = PrintAbstract::getById($request->query->getInt('id'));
+        $document = PrintAbstract::getById(ParameterBagHelper::getInt($request->query, 'id'));
 
         if (!$document) {
-            throw $this->createNotFoundException('Document with id ' . $request->query->getInt('id') . ' not found.');
+            throw $this->createNotFoundException('Document with id ' . ParameterBagHelper::getInt($request->query, 'id') . ' not found.');
         }
 
         if ($this->checkFileExists($document->getPdfFileName())) {
@@ -317,7 +318,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
     #[Route('/check-pdf-dirty', name: 'checkpdfdirty', methods: ['GET'])]
     public function checkPdfDirtyAction(Request $request): JsonResponse
     {
-        $printDocument = PrintAbstract::getById($request->query->getInt('id'));
+        $printDocument = PrintAbstract::getById(ParameterBagHelper::getInt($request->query, 'id'));
 
         $dirty = true;
         if ($printDocument) {
@@ -334,7 +335,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
 
         $returnValue = [];
 
-        $storedValues = $this->getStoredProcessingOptions($request->query->getInt('id'));
+        $storedValues = $this->getStoredProcessingOptions(ParameterBagHelper::getInt($request->query, 'id'));
 
         foreach ($options as $option) {
             $value = $option['default'];
@@ -378,7 +379,7 @@ abstract class PrintpageControllerBase extends DocumentControllerBase
     #[Route('/cancel-generation', name: 'cancelgeneration', methods: ['DELETE'])]
     public function cancelGenerationAction(Request $request): JsonResponse
     {
-        Processor::getInstance()->cancelGeneration($request->request->getInt('id'));
+        Processor::getInstance()->cancelGeneration(ParameterBagHelper::getInt($request->request, 'id'));
 
         return $this->adminJson(['success' => true]);
     }

--- a/src/Controller/Document/PrintpageControllerBase.php
+++ b/src/Controller/Document/PrintpageControllerBase.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\WebToPrintBundle\Controller\Document;
 
-use Pimcore\Helper\ParameterBagHelper;
 use Exception;
 use Pimcore\Bundle\AdminBundle\Controller\Admin\Document\DocumentControllerBase;
 use Pimcore\Bundle\WebToPrintBundle\Config;
 use Pimcore\Bundle\WebToPrintBundle\Model\Document\PrintAbstract;
 use Pimcore\Bundle\WebToPrintBundle\Processor;
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Logger;
 use Pimcore\Model\Document;
 use Pimcore\Model\Element\ValidationException;

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -240,6 +240,7 @@ abstract class Processor
     {
         $document = $params['document'] ?? null;
         $hostUrl = $params['hostUrl'] ?? null;
+        trigger_deprecation('pimcore/pimcore', '12.3', 'Retrieving "pimcore.templating.engine.delegating" from the container is deprecated and will be removed in 13.0. Inject Twig\Environment directly instead.');
         $templatingEngine = \Pimcore::getContainer()->get('pimcore.templating.engine.delegating');
 
         try {


### PR DESCRIPTION
This pull request refactors the way integer parameters are retrieved from HTTP requests in the `PrintpageControllerBase` class, replacing direct calls to Symfony's `Request` object with the centralized `ParameterBagHelper::getInt` method. This improves consistency and reliability when accessing request parameters. Additionally, a deprecation warning is added in the `Processor` class to guide future changes in template engine usage.

**Controller parameter handling improvements:**

* All instances of `$request->query->getInt('id')` and `$request->request->getInt('id')` in `PrintpageControllerBase.php` are replaced with `ParameterBagHelper::getInt(...)` for more robust and consistent parameter extraction. [[1]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bR16) [[2]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL41-R42) [[3]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL88-R89) [[4]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL139-R140) [[5]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL168-R169) [[6]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL194-R195) [[7]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL233-R237) [[8]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL266-R270) [[9]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL320-R321) [[10]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL337-R338) [[11]](diffhunk://#diff-d2bc1d1c838e1c255334d7d765459c340612596c36b38ba83f1187132b92909bL381-R382)

**Deprecation notice for template engine usage:**

* Added a `trigger_deprecation` call in `Processor.php` to warn that retrieving `pimcore.templating.engine.delegating` from the container is deprecated and will be removed in Pimcore 13.0; developers should inject `Twig\Environment` directly.