### PR TITLE
Update matrix ref in sync-changes-scheduled.yml

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yml
+++ b/.github/workflows/sync-changes-scheduled.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ref: [{'base': '2.x', 'destination': '2.x'},{'base': '2.0', 'destination': '2.0'},{'base': '1.1', 'destination': '1.1'},{'base': '1.4', 'destination': '1.4'}]
+        ref: [{'base': '1.1', 'destination': '1.1'},{'base': '1.4', 'destination': '1.4'}]
     with:
       base_ref: ${{ matrix.ref.base }}
       ref_name: ${{ matrix.ref.destination }}


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/sync-changes-scheduled.yml` workflow configuration. The change reduces the set of branches targeted by the sync job.

- Updated the `matrix.ref` in the workflow to only include the `1.1` and `1.4` branches, removing `2.x` and `2.0` from the sync process.