### PR TITLE
Allow method parameters to override bundle configuration

### DIFF
--- a/src/Processor/Gotenberg.php
+++ b/src/Processor/Gotenberg.php
@@ -96,7 +96,7 @@ class Gotenberg extends Processor
                 unset($gotenbergSettings[$item]);
             }
 
-            $params = array_merge($params, $gotenbergSettings);
+            $params = array_merge($gotenbergSettings, $params);
         }
 
         $params = $params ?: $this->getDefaultOptions();


### PR DESCRIPTION
The method parameters should take precedence over the bundle configuration. In my understanding, the bundle configuration is meant to provide defaults while the method parameters should specify values specific to this call.