### PR TITLE
Update workflow to remove version 1.1 references

### DIFF
--- a/.github/workflows/sync-changes-scheduled.yml
+++ b/.github/workflows/sync-changes-scheduled.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ref: [{'base': '1.1', 'destination': '1.1'},{'base': '1.4', 'destination': '1.4'}]
+        ref: [{'base': '1.4', 'destination': '1.4'}]
     with:
       base_ref: ${{ matrix.ref.base }}
       ref_name: ${{ matrix.ref.destination }}


### PR DESCRIPTION
Removed the base and destination reference for version 1.1 from the workflow matrix.